### PR TITLE
Updating env propety set provider inner loop to check for valid point…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: php
 php:
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
 
 before_script:
   - composer self-update

--- a/Fliglio/Config/EnvPropertySetProvider.php
+++ b/Fliglio/Config/EnvPropertySetProvider.php
@@ -3,6 +3,7 @@
 namespace Fliglio\Config;
 
 class EnvPropertySetProvider implements PropertySetProvider {
+
 	private $config;
 
 	// only provide an argument for test
@@ -10,7 +11,7 @@ class EnvPropertySetProvider implements PropertySetProvider {
 		if (is_null($config)) {
 			$config = $_ENV;
 		}
-		$this->config = $config;		
+		$this->config = $config;
 	}
 
 	public function build() {
@@ -29,9 +30,15 @@ class EnvPropertySetProvider implements PropertySetProvider {
 				}
 
 				$pointer = &$pointer[$key_level];
+
+				// type safety for potential downstream arrays that may have already
+				// been assigned as a string value
+				// see EnvPropertyTest.testChildArrayAndValueOverwrite()
+				$pointer = !is_array($pointer) ? [] : $pointer;
 			}
 
 			$pointer = !is_array($pointer) ? [] : $pointer;
+
 			if (!isset($pointer[$key_last])) {
 				$pointer[$key_last] = $value;
 			}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
         "name": "Ben Schwartz",
         "email": "benschw@gmail.com"
     }],
-    "minimum-stability" : "dev",
     "require": {
         "php"                       : ">=5.4",
         "symfony/yaml"              : "3.* || 2.*",

--- a/test/EnvPropertyTest.php
+++ b/test/EnvPropertyTest.php
@@ -42,7 +42,37 @@ class EnvPropertyTest extends \PHPUnit_Framework_TestCase {
 		$this->assertEquals($config['fliglio'], 'foo');
 	}
 
-	public function testArrayAndValue() {
+	public function testChildArrayAndValueOverwrite() {
+		// given
+		$config = [
+			"FOO_BAR" => 'foo',
+			"FOO_BAR_BAZ_BOO" => 'hoo'
+		];
+		$provider = new EnvPropertySetProvider($config);
+
+		// when
+		$config = $provider->build();
+
+		// then
+		$this->assertEquals('hoo', $config['foo']['bar']['baz']['boo']);
+	}
+
+	public function testChildArrayAndValueOverwrite_OppositeOrderArrayWins() {
+		// given
+		$config = [
+			"FOO_BAR_BAZ_BOO" => 'hoo',
+			"FOO_BAR" => 'foo'
+		];
+		$provider = new EnvPropertySetProvider($config);
+
+		// when
+		$config = $provider->build();
+
+		// then
+		$this->assertEquals('hoo', $config['foo']['bar']['baz']['boo']);
+	}
+
+	public function testRootArrayAndValueOverwrite() {
 		// given
 		$config = [
 			"BAX" => 'doo',
@@ -57,10 +87,10 @@ class EnvPropertyTest extends \PHPUnit_Framework_TestCase {
 		// then
 		$this->assertEquals('doo', $config['bax']);
 		$this->assertEquals('baz', $config['foo']['bar']);
-		$this->assertEquals(['bar' => 'baz'], $config['foo']);
+		$this->assertEquals('baz', $config['foo']['bar']);
 	}
 
-	public function testArrayAndValueOppositeOrder() {
+	public function testRootArrayAndValueOverwrite_OppositeOrderArrayWins() {
 		// given
 		$config = [
 			"FOO_BAR" => 'baz',
@@ -72,7 +102,7 @@ class EnvPropertyTest extends \PHPUnit_Framework_TestCase {
 		$config = $provider->build();
 
 		// then
-		$this->assertEquals(['bar' => 'baz'], $config['foo']);
+		$this->assertEquals('baz', $config['foo']['bar']);
 	}
 
 }


### PR DESCRIPTION
Children nodes (inner foreach) was not checking for valid pointer types like the root (outer foreach) was which was causing certain var to break on the array access. 